### PR TITLE
fix: `includeIfNull: false` silently dropping null values for spec-nu…

### DIFF
--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -466,9 +466,13 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
     }
   }
 
-  String generateIncludeIfNullString() {
+  String generateIncludeIfNullString(SwaggerSchema prop) {
     if (options.includeIfNull == null) {
       return '';
+    }
+
+    if (prop.isSpecNullable && options.includeIfNull == false) {
+      return ', includeIfNull: true';
     }
 
     return ', includeIfNull: ${options.includeIfNull}';
@@ -543,7 +547,7 @@ class $className implements json.JsonConverter<${value.type}, dynamic> {
 
     final dateToJsonValue = generateToJsonForDate(prop);
 
-    final includeIfNullString = generateIncludeIfNullString();
+    final includeIfNullString = generateIncludeIfNullString(prop);
 
     if (typeName != kDynamic &&
         (prop.shouldBeNullable || options.nullableModels.contains(typeName))) {
@@ -731,7 +735,7 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
       );
     }
 
-    final includeIfNullString = generateIncludeIfNullString();
+    final includeIfNullString = generateIncludeIfNullString(prop);
 
     final allEnumsNamesWithoutPrefix = allEnumNames
         .map((e) => e.replaceFirst('enums.', ''))
@@ -909,7 +913,7 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
     );
 
     final dateToJsonValue = generateToJsonForDate(resolvedSchemaForDetails);
-    final includeIfNullString = generateIncludeIfNullString();
+    final includeIfNullString = generateIncludeIfNullString(prop);
 
     final jsonKeyContent =
         "@JsonKey(name: '$propertyKey'$includeIfNullString$dateToJsonValue${unknownEnumValue.jsonKey})\n";
@@ -952,7 +956,7 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
       typeName = basicTypesMap[typeName]!;
     }
 
-    final includeIfNullString = generateIncludeIfNullString();
+    final includeIfNullString = generateIncludeIfNullString(prop);
 
     final unknownEnumValue = generateEnumValue(
       allEnumNames: allEnumNames,
@@ -1038,7 +1042,7 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
       typeName = 'List<$typeName>';
     }
 
-    final includeIfNullString = generateIncludeIfNullString();
+    final includeIfNullString = generateIncludeIfNullString(prop);
 
     final jsonKeyContent =
         "@JsonKey(name: '${_validatePropertyKey(propertyKey)}'$includeIfNullString${unknownEnumValue.jsonKey})\n";
@@ -1111,7 +1115,7 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
       isNullable: isNullable(className, requiredProperties, propertyKey, prop),
     );
 
-    final includeIfNullString = generateIncludeIfNullString();
+    final includeIfNullString = generateIncludeIfNullString(prop);
 
     var enumPropertyName = className.capitalize + key.capitalize;
 
@@ -1243,7 +1247,7 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
       isNullable: false,
     );
 
-    final includeIfNullString = generateIncludeIfNullString();
+    final includeIfNullString = generateIncludeIfNullString(prop);
     final validatedPropertyKey = _validatePropertyKey(propertyKey);
 
     String jsonKeyContent;
@@ -1301,7 +1305,7 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
     required List<String> requiredProperties,
     required bool isDeprecated,
   }) {
-    final includeIfNullString = generateIncludeIfNullString();
+    final includeIfNullString = generateIncludeIfNullString(prop);
     final jsonConverterAnnotation = generatePropertyJsonConverterAnnotation(prop);
 
     var jsonKeyContent =

--- a/lib/src/swagger_models/responses/swagger_schema.dart
+++ b/lib/src/swagger_models/responses/swagger_schema.dart
@@ -112,11 +112,14 @@ class SwaggerSchema {
   @JsonKey(name: 'nullable')
   bool? isNullable;
 
-  bool get shouldBeNullable =>
+  bool get isSpecNullable =>
       isNullable == true ||
-      readOnly ||
-      writeOnly ||
       (_type is List && (_type as List).contains('null'));
+
+  bool get shouldBeNullable =>
+      isSpecNullable ||
+      readOnly ||
+      writeOnly;
 
   @JsonKey(name: 'schema')
   SwaggerSchema? schema;

--- a/test/generator_tests/models_generator_test.dart
+++ b/test/generator_tests/models_generator_test.dart
@@ -226,6 +226,26 @@ void main() {
       expect(result, contains(', includeIfNull: false'));
     });
 
+    test('Should generate includeIfNull: true for spec-nullable fields even when option is false', () {
+      final propertyEntryMap = SwaggerSchema(originalRef: 'Pet', isNullable: true);
+      const propertyName = 'shipDate';
+      final result = SwaggerModelsGeneratorV3(GeneratorOptions(
+        inputFolder: '',
+        outputFolder: '',
+        includeIfNull: false,
+      )).generatePropertyContentByDefault(
+        prop: propertyEntryMap,
+        propertyName: propertyName,
+        propertyKey: propertyName,
+        allEnumNames: [],
+        allEnumListNames: [],
+        requiredProperties: [],
+        isDeprecated: false,
+      );
+
+      expect(result, contains(', includeIfNull: true'));
+    });
+
     test('Should NOT generate includeIfNull if option is false', () {
       final propertyEntryMap = SwaggerSchema(originalRef: 'Pet');
       const propertyName = 'shipDate';


### PR DESCRIPTION
## Current behaviour

When `include_if_null` was set to `false` globally, fields explicitly marked `nullable: true` in the OpenAPI spec would have their null values omitted during serialization. This is incorrect because the spec author declared `null` as a valid, intentional value for those fields.

## Incoming/Expected behaviour
Fields with spec-declared nullability (`nullable: true` or type array containing `null`) get `includeIfNull: true` regardless of the global setting, ensuring `null` values are always serialized for those fields.